### PR TITLE
Add rust-bert Docker setup

### DIFF
--- a/.github/docker/rust-bert/Dockerfile
+++ b/.github/docker/rust-bert/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.io/rocm/pytorch:latest
+
+# Install Rust toolchain
+RUN apt-get update && apt-get install -y --no-install-recommends curl git build-essential && \
+    curl https://sh.rustup.rs -sSf | bash -s -- -y && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV LIBTORCH=/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch
+ENV LD_LIBRARY_PATH=${LIBTORCH}/lib:$LD_LIBRARY_PATH
+
+WORKDIR /workspace
+
+RUN git clone https://github.com/guillaume-be/rust-bert.git
+
+WORKDIR /workspace/rust-bert
+
+CMD ["bash", "-lc", "cargo run --example sentence_embeddings"]

--- a/.github/docker/rust-bert/Dockerfile
+++ b/.github/docker/rust-bert/Dockerfile
@@ -15,4 +15,4 @@ RUN git clone https://github.com/guillaume-be/rust-bert.git
 
 WORKDIR /workspace/rust-bert
 
-CMD ["bash", "-lc", "cargo run --example sentence_embeddings"]
+CMD ["cargo", "run", "--example", "sentence_embeddings"]

--- a/.github/docker/rust-bert/docker-compose.yml
+++ b/.github/docker/rust-bert/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  rust-bert:
+    build: .
+    image: rust-bert:latest
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary
- add Dockerfile & compose configuration under `.github/docker/rust-bert`
- use `rocm/pytorch:latest` as base image
- clone and run the `rust-bert` sentence embedding example

## Testing
- `make test`
- `make fmt-check` *(fails: rustfmt download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686cd3469a10833182959e114f0090c4