### PR TITLE
Improve n8n LXC setup ID detection and error handling

### DIFF
--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -6,9 +6,9 @@ script provisions an Ubuntu 24.04 LXC container to run
 
 ## `n8n-lxc-setup.sh`
 
-`n8n-lxc-setup.sh` creates an unprivileged LXC container with 4 vCPUs and
-4&nbsp;GB of RAM, installs Node.js 18 and n8n, and configures n8n as a
-systemd service.
+`n8n-lxc-setup.sh` creates an unprivileged LXC container with 4 vCPUs,
+8&nbsp;GB of RAM, and 80&nbsp;GB of storage. It installs Node.js 18 and n8n and
+configures n8n as a systemd service.
 
 ### Usage
 

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -45,6 +45,14 @@ The container defines two users:
 | `root` | *(none)* | Access via `pct enter` or set a password with `passwd`. |
 | `n8n` | *(none)* | Runs the service and cannot log in (`/usr/sbin/nologin`). |
 
+### Accessing n8n
+
+After the script finishes it prints a URL like `http://192.0.2.10:5678`.
+Open the address in a browser. On first launch n8n prompts you to create an
+account by entering an email address and password. Choose any credentials you
+like; there is no default username or password. Use this account to log in on
+subsequent visits.
+
 ### API keys
 
 The environment file contains placeholders for the following keys:

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -14,6 +14,13 @@ Run the script on the Proxmox host as root:
 bash n8n-lxc-setup.sh
 ```
 
+By default the script chooses the next free container ID. You can override it by
+passing a custom ID as the first argument:
+
+```bash
+bash n8n-lxc-setup.sh 200   # use CTID 200
+```
+
 The script will:
 
 1. download the Ubuntu 24.04 LXC template if needed;

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -1,10 +1,14 @@
 # Proxmox Scripts
 
-This directory contains Proxmox helper scripts and setup guides. The first script provisions an Ubuntu 24.04 LXC container to run [n8n](https://n8n.io/) without Docker.
+This directory contains Proxmox helper scripts and setup guides. The first
+script provisions an Ubuntu 24.04 LXC container to run
+[n8n](https://n8n.io/) without Docker.
 
 ## `n8n-lxc-setup.sh`
 
-`n8n-lxc-setup.sh` creates an unprivileged LXC container with 4 vCPUs and 4&nbsp;GB of RAM, installs Node.js 18 and n8n, and configures n8n as a systemd service.
+`n8n-lxc-setup.sh` creates an unprivileged LXC container with 4 vCPUs and
+4&nbsp;GB of RAM, installs Node.js 18 and n8n, and configures n8n as a
+systemd service.
 
 ### Usage
 
@@ -23,13 +27,14 @@ bash n8n-lxc-setup.sh 200   # use CTID 200
 
 The script will:
 
-1. download the Ubuntu 24.04 LXC template if needed;
+1. download the latest Ubuntu 24.04 LXC template if needed;
 2. create the container with DHCP networking on `vmbr0`;
 3. install Node.js and n8n inside the container;
 4. create `/etc/n8n.env` with placeholders for API keys;
 5. register and start the `n8n` service.
 
-Edit `/etc/n8n.env` in the container after creation to add your real API keys and restart the service with `systemctl restart n8n`.
+Edit `/etc/n8n.env` in the container after creation to add your real API keys
+and restart the service with `systemctl restart n8n`.
 
 ### API keys
 
@@ -40,11 +45,14 @@ OPENAI_API_KEY="YOUR_OPENAI_API_KEY"
 ANTHROPIC_API_KEY="YOUR_ANTHROPIC_API_KEY"
 ```
 
-Additional keys can be appended as new lines in `/etc/n8n.env`. n8n nodes can reference them using expressions such as `{{$env["OPENAI_API_KEY"]}}`.
+Additional keys can be appended as new lines in `/etc/n8n.env`. n8n nodes can
+reference them using expressions such as `{{$env["OPENAI_API_KEY"]}}`.
 
 ## Example n8n workflow
 
-Once n8n is running you can create a workflow that gathers machine-learning news from RSS feeds and URLs, summarizes the articles with OpenAI **o4-mini**, and sends the results by email, Telegram bot and Discord.
+Once n8n is running you can create a workflow that gathers machine-learning
+news from RSS feeds and URLs, summarizes the articles with OpenAI
+**o4-mini**, and sends the results by email, Telegram bot and Discord.
 
 A high level outline:
 
@@ -54,4 +62,3 @@ A high level outline:
 4. **Send** the summary via Email, Telegram and Discord nodes.
 
 This provides an automated daily digest of recent ML research.
-

--- a/proxmox/README.md
+++ b/proxmox/README.md
@@ -36,6 +36,15 @@ The script will:
 Edit `/etc/n8n.env` in the container after creation to add your real API keys
 and restart the service with `systemctl restart n8n`.
 
+### Accounts
+
+The container defines two users:
+
+| User | Password | Notes |
+| ---- | -------- | ----- |
+| `root` | *(none)* | Access via `pct enter` or set a password with `passwd`. |
+| `n8n` | *(none)* | Runs the service and cannot log in (`/usr/sbin/nologin`). |
+
 ### API keys
 
 The environment file contains placeholders for the following keys:

--- a/proxmox/n8n-lxc-setup.sh
+++ b/proxmox/n8n-lxc-setup.sh
@@ -109,4 +109,6 @@ if [ -z "$CONTAINER_IP" ]; then
     echo "Container IP address is empty" >&2
     exit 1
 fi
-echo "✅ n8n installation complete! You can now access n8n at http://$CONTAINER_IP:5678"
+echo "✅ n8n installation complete!"
+echo "Open http://$CONTAINER_IP:5678 in your browser to finish setup."
+echo "On first visit you'll be prompted to create an n8n account; there are no default credentials."

--- a/proxmox/n8n-lxc-setup.sh
+++ b/proxmox/n8n-lxc-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Proxmox LXC deployment script for n8n (Ubuntu 24.04 LTS)
-# Resources: 4 vCPU, 4096 MB RAM, 10 GB disk (adjustable)
+# Resources: 4 vCPU, 8192 MB RAM, 80 GB disk (adjustable)
 
 set -euo pipefail
 trap 'echo "❌ Script failed at line $LINENO." >&2; exit 1' ERR
@@ -25,8 +25,8 @@ fi
 
 HOSTNAME="n8n-server"         # Container hostname
 CORES=4                       # vCPU cores for the container
-MEMORY=4096                   # RAM in MB for the container
-DISK_SIZE=10                  # Disk size in GB for container rootfs
+MEMORY=8192                   # RAM in MB for the container
+DISK_SIZE=80                  # Disk size in GB for container rootfs
 TEMPLATE_BASE="ubuntu-24.04-standard"  # Base name for Ubuntu 24.04 LTS template
 STORAGE_POOL="local-lvm"      # Proxmox storage pool for the container
 

--- a/proxmox/n8n-lxc-setup.sh
+++ b/proxmox/n8n-lxc-setup.sh
@@ -2,8 +2,23 @@
 # Proxmox LXC deployment script for n8n (Ubuntu 24.04 LTS)
 # Resources: 4 vCPU, 4096 MB RAM, 10 GB disk (adjustable)
 
+set -euo pipefail
+trap 'echo "❌ Script failed at line $LINENO." >&2' ERR
+
 ### 1. Define variables ###
-CTID=101                      # Container ID (change if needed)
+# Allow CTID to be provided as an argument or environment variable
+CTID="${1:-${CTID:-}}"
+if [ -z "$CTID" ]; then
+    echo "Detecting next available container ID..."
+    CTID=$(pvesh get /cluster/nextid) || { echo "Failed to determine next container ID" >&2; exit 1; }
+fi
+
+# Ensure the chosen CTID is not already in use
+if pct list | awk 'NR>1 {print $1}' | grep -qw "$CTID" || qm list | awk 'NR>1 {print $1}' | grep -qw "$CTID"; then
+    echo "Container ID $CTID is already in use." >&2
+    exit 1
+fi
+
 HOSTNAME="n8n-server"         # Container hostname
 CORES=4                       # vCPU cores for the container
 MEMORY=4096                   # RAM in MB for the container
@@ -20,35 +35,35 @@ fi
 
 ### 3. Create the LXC container ###
 echo "Creating LXC container $CTID ($HOSTNAME)..."
-pct create $CTID local:vztmpl/$TEMPLATE* -hostname $HOSTNAME \
-    -cores $CORES -memory $MEMORY -rootfs $STORAGE_POOL:$DISK_SIZE \
+pct create "$CTID" local:vztmpl/$TEMPLATE* -hostname "$HOSTNAME" \
+    -cores "$CORES" -memory "$MEMORY" -rootfs "$STORAGE_POOL:$DISK_SIZE" \
     -net0 name=eth0,bridge=vmbr0,ip=dhcp -unprivileged 1 -features nesting=1,keyctl=1
 
 ### 4. Start the container ###
-pct start $CTID
+pct start "$CTID"
 echo "Container $CTID started. Installing n8n and dependencies..."
 
 ### 5. Update apt and install Node.js (v18 LTS) & build tools inside container ###
-pct exec $CTID -- apt-get update
-pct exec $CTID -- apt-get upgrade -y
-pct exec $CTID -- apt-get install -y curl gnupg build-essential
-pct exec $CTID -- bash -c "curl -fsSL https://deb.nodesource.com/setup_18.x | bash -"
-pct exec $CTID -- apt-get install -y nodejs
+pct exec "$CTID" -- apt-get update
+pct exec "$CTID" -- apt-get upgrade -y
+pct exec "$CTID" -- apt-get install -y curl gnupg build-essential
+pct exec "$CTID" -- bash -c "curl -fsSL https://deb.nodesource.com/setup_18.x | bash -"
+pct exec "$CTID" -- apt-get install -y nodejs
 
 ### 6. Install n8n globally using npm ###
-pct exec $CTID -- npm install -g n8n
+pct exec "$CTID" -- npm install -g n8n
 
 ### 7. Create a dedicated n8n user ###
-pct exec $CTID -- useradd -m -s /usr/sbin/nologin n8n
+pct exec "$CTID" -- useradd -m -s /usr/sbin/nologin n8n
 
 ### 8. Prepare environment file for API keys (placeholders for now) ###
-pct exec $CTID -- bash -c "echo 'OPENAI_API_KEY=\"YOUR_OPENAI_API_KEY\"' > /etc/n8n.env"
-pct exec $CTID -- bash -c "echo 'ANTHROPIC_API_KEY=\"YOUR_ANTHROPIC_API_KEY\"' >> /etc/n8n.env"
-pct exec $CTID -- bash -c "chmod 600 /etc/n8n.env"
-pct exec $CTID -- bash -c "chown n8n:n8n /etc/n8n.env"
+pct exec "$CTID" -- bash -c "echo 'OPENAI_API_KEY=\"YOUR_OPENAI_API_KEY\"' > /etc/n8n.env"
+pct exec "$CTID" -- bash -c "echo 'ANTHROPIC_API_KEY=\"YOUR_ANTHROPIC_API_KEY\"' >> /etc/n8n.env"
+pct exec "$CTID" -- bash -c "chmod 600 /etc/n8n.env"
+pct exec "$CTID" -- bash -c "chown n8n:n8n /etc/n8n.env"
 
 ### 9. Create systemd service for n8n ###
-pct exec $CTID -- bash -c "cat >/etc/systemd/system/n8n.service <<'SERVICE'
+pct exec "$CTID" -- bash -c "cat >/etc/systemd/system/n8n.service <<'SERVICE'
 [Unit]
 Description=n8n Automation Service
 After=network.target
@@ -66,8 +81,13 @@ WantedBy=multi-user.target
 SERVICE"
 
 ### 10. Enable and start the n8n service ###
-pct exec $CTID -- systemctl daemon-reload
-pct exec $CTID -- systemctl enable n8n.service
-pct exec $CTID -- systemctl start n8n.service
+pct exec "$CTID" -- systemctl daemon-reload
+pct exec "$CTID" -- systemctl enable n8n.service
+pct exec "$CTID" -- systemctl start n8n.service
 
-echo "✅ n8n installation complete! You can now access n8n at http://<container-IP>:5678"
+# Ensure the service is running before reporting success
+pct exec "$CTID" -- systemctl is-active --quiet n8n.service
+
+# Fetch the container's IP address for the final message
+CONTAINER_IP=$(pct exec "$CTID" -- hostname -I | awk '{print $1}')
+echo "✅ n8n installation complete! You can now access n8n at http://$CONTAINER_IP:5678"


### PR DESCRIPTION
## Summary
- detect the next available Proxmox container ID automatically and fail if ID is already in use
- verify n8n service startup and display container IP on success
- document how to override the auto-chosen container ID

## Testing
- `shellcheck proxmox/n8n-lxc-setup.sh`
- `npx --yes markdownlint-cli proxmox/README.md` *(fails: MD013 line-length, MD012 no-multiple-blanks)*

------
https://chatgpt.com/codex/tasks/task_e_688f7483cadc83318bec431bec4e61dd